### PR TITLE
feat/content-pages: research, teaching, and outreach pages

### DIFF
--- a/content/outreach/_index.md
+++ b/content/outreach/_index.md
@@ -1,0 +1,17 @@
+---
+title: Outreach & Mentoring
+type: page
+---
+
+Beyond research and teaching, I care about widening access to physics and
+supporting the next generation of scientists.
+
+**Mentoring.** I supervise graduate and undergraduate researchers in the
+[UM Neutrino group](https://www.umneutrino.com), with an emphasis on
+research skills, scientific communication, and career development.
+
+**Service.** I serve on the
+[APS DPF Coordinating Panel for Software & Computing (CPSC)](https://www.aps.org/units/dpf/),
+leading the Rising Star Awards Sub-Committee. Past roles include
+Chairperson of the Fermilab Users Executive Committee (2018–2019) and
+Computing Co-Chair of [ICHEP 2024](https://ichep2024.org/) in Prague.

--- a/content/research/_index.md
+++ b/content/research/_index.md
@@ -1,0 +1,38 @@
+---
+title: Research
+type: page
+---
+
+I'm fascinated by neutrinos — particles so weakly interacting that trillions
+pass through you each second unnoticed, yet whose tiny, shifting masses may
+hold clues to why the universe is made of matter at all. My group at the
+University of Mississippi works on **neutrino oscillation physics**: measuring
+how neutrinos change "flavor" as they travel hundreds of kilometers.
+
+**Long-baseline oscillations (NOvA & DUNE).** I collaborate on Fermilab's
+[NOvA](https://novaexperiment.fnal.gov/) experiment, which fires an intense
+neutrino beam from Illinois to a detector in northern Minnesota to measure
+oscillation parameters with increasing precision. I serve as the Mississippi
+Principal Investigator for [DUNE](https://www.dunescience.org/), the Deep
+Underground Neutrino Experiment — the flagship next-generation effort to pin
+down the neutrino mass ordering and search for charge-parity (CP) violation
+in the lepton sector.
+
+**Combining experiments.** Some of the most powerful constraints come from
+joint analyses across experiments with complementary designs. Recent work
+bringing together NOvA and Japan's T2K produced among the most precise
+measurements yet of neutrino oscillation parameters.
+
+**Hadron production (EMPHATIC).** Better oscillation measurements demand
+better models of how the neutrino beams are produced in the first place. I
+serve as [EMPHATIC](https://emphatic.fnal.gov/) Software & Analysis
+Coordinator, working on measurements of hadron-production cross sections that
+feed directly into reducing systematic uncertainties for NOvA and DUNE.
+
+**Computing & software.** I serve as NOvA Computing Coordinator and have
+broad interests in scientific software, simulation, and analysis
+infrastructure. My group develops Monte Carlo tools and data-analysis
+techniques that underpin neutrino oscillation measurements.
+
+For group members, publications, and news, visit the
+[UM Neutrino group site](https://www.umneutrino.com).

--- a/content/teaching/_index.md
+++ b/content/teaching/_index.md
@@ -1,0 +1,23 @@
+---
+title: Teaching
+type: page
+---
+
+I teach across the introductory and graduate physics curriculum at Ole Miss.
+
+- **PHYS 211 — Physics for Scientists & Engineers I.** Calculus-based
+  introductory mechanics.
+- **PHYS 212 — Physics for Scientists & Engineers II.** Calculus-based
+  electricity, magnetism, and optics.
+- **PHYS 503 — Science Communication.** Graduate-level course on
+  communicating scientific work to specialist and general audiences.
+- **PHYS 709 — Advanced Mechanics I.** Graduate classical mechanics.
+- **PHYS 510 — Department Colloquium.** Graduate seminar series.
+
+I also serve as **Graduate Program Coordinator** for the Department of
+Physics & Astronomy, working with prospective and current graduate students
+on admissions, degree requirements, and career development.
+
+Graduate and undergraduate researchers interested in joining the group
+should visit the [UM Neutrino group site](https://www.umneutrino.com) or
+[get in touch](/#contact) directly.


### PR DESCRIPTION
## Summary

- `content/research/_index.md` — neutrino oscillation overview, NOvA, DUNE (MS PI), EMPHATIC S&A Coordinator, computing roles; routes to group site for depth
- `content/teaching/_index.md` — PHYS 211/212/503/709/510 with descriptions; Graduate Program Coordinator note
- `content/outreach/_index.md` — mentoring, APS CPSC service (Rising Star Awards lead), ICHEP 2024, FUC chair 2018–2019

All content sourced from `~/github/cv` — titles and roles verified against the CV.

## Build status

Clean build, 863 ms, no errors.

🤖 Assisted by Claude Code (claude-sonnet-4-6)