### PR TITLE
feat/deploy: Netlify config, custom domain, www redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,14 +1,15 @@
 [build]
-  command = "hugo --gc --minify"
+  command = "npm install && hugo --gc --minify"
   publish = "public"
 
 [build.environment]
   HUGO_VERSION = "0.162.1"
   HUGO_ENVIRONMENT = "production"
+  NODE_VERSION = "22"
   TZ = "America/Chicago"
 
 [context.deploy-preview]
-  command = "hugo --gc --minify --buildFuture -b $DEPLOY_PRIME_URL"
+  command = "npm install && hugo --gc --minify --buildFuture -b $DEPLOY_PRIME_URL"
 
 [context.branch-deploy]
-  command = "hugo --gc --minify -b $DEPLOY_PRIME_URL"
+  command = "npm install && hugo --gc --minify -b $DEPLOY_PRIME_URL"

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+gavinsdavies.com

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,0 +1,2 @@
+# Redirect www to apex domain
+https://www.gavinsdavies.com/* https://gavinsdavies.com/:splat 301!


### PR DESCRIPTION
## Summary

- `netlify.toml`: adds `npm install` to build command so TailwindCSS CLI resolves on Netlify's build image; pins `NODE_VERSION=22`
- `static/CNAME`: sets canonical domain to `gavinsdavies.com`
- `static/_redirects`: 301 redirect from `www.gavinsdavies.com` → apex domain

## To activate

1. Connect the `gavinsdavies/gavinsdavies.com` repo to Netlify (New site → Import from Git → select repo, branch: `hugo-blox-migration` for now, `main` after final merge)
2. In Netlify → Domain settings: add custom domain `gavinsdavies.com`; point DNS `A`/`AAAA` records to Netlify's load balancer IPs

## Build status

Clean build, 647 ms; CNAME and _redirects confirmed in `public/`.

🤖 Assisted by Claude Code (claude-sonnet-4-6)